### PR TITLE
update: 支持Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,22 @@ language: go
 go:
   - 1.11.x
 
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install libasound2-dev; fi
+
 install: go build -o jikefm
 
-os: osx
+os:
+  - osx
+  - linux
 
 env:
   - GO111MODULE=on
 
 before_deploy:
   - go build -o jikefm
-  - tar cvzf jikefm-darwin-amd64.tgz jikefm
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then tar cvzf jikefm-darwin-amd64.tgz jikefm; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar cvzf jikefm-linux-amd64.tgz jikefm; fi
   - ls
 
 deploy:
@@ -20,6 +26,7 @@ deploy:
   api_key: $AUTH_TOKEN
   file:
     - "jikefm-darwin-amd64.tgz"
+    - "jikefm-linux-amd64.tgz"
 
   skip_cleanup: true
   on:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@ JIKEFM - 即刻电台📻
 - 动态加载更多
 - 支持晚安电台、早安歌曲、即友在听什么歌
 
+## Dependencies
+
+Linux 系统需要依赖 libasound2-dev，安装方法：
+
+`sudo apt-get install libasound2-dev`
+
+- [beep](https://github.com/faiface/beep)
+- [tview](https://github.com/rivo/tview)
+- [tview](https://github.com/gdamore/tcell)
+- [qrterminal](https://github.com/mdp/qrterminal)
+
 ## Install
 
 `go get -u github.com/0nese7en/jikefm`
@@ -23,12 +34,6 @@ JIKEFM - 即刻电台📻
 - [x] 支持更多的Topic
 - [x] 优化UI
 - [ ] 支持除网易云音乐以外的更多歌曲
-
-## Dependencies
-- [beep](https://github.com/faiface/beep)
-- [tview](https://github.com/rivo/tview)
-- [tview](https://github.com/gdamore/tcell)
-- [qrterminal](https://github.com/mdp/qrterminal)
 
 ---
 


### PR DESCRIPTION
支持 Linux

顺便改了 `travis.yml`，使其可以方便的部署 MacOS 版和 Linux 版的 jikefm